### PR TITLE
ajout du champ siret avec la regex

### DIFF
--- a/dematik/blocks-publik/siret.j2
+++ b/dematik/blocks-publik/siret.j2
@@ -1,0 +1,3 @@
+{# field_data -#}
+{%- from "macros-publik/champ_texte.j2" import champ_texte with context -%}
+{{ champ_texte(field_data, validation='[0-9]{14}') }}


### PR DESCRIPTION
Ajout du champ siret dans les block-publik : siret.j2
Création sur le modèle de montant.j2 en ajoutant la regex "14 chiffres" ([0-9]{14})