### PR TITLE
ajout du champ tableau libre

### DIFF
--- a/dematik/blocks-publik/tableau_libre.j2
+++ b/dematik/blocks-publik/tableau_libre.j2
@@ -1,0 +1,11 @@
+{# field_data -#}
+{% from "macros-publik/entete.j2" import entete with context -%}
+<field>
+    {{ entete(field_data, "tablerows", extra_css_class) }}
+	<columns>
+		{% for term in get_items(field_data) -%}
+			<column>{{ term }}</column>
+		{% endfor -%}
+	</columns>
+	<total_row>False</total_row>
+</field>


### PR DESCRIPTION
Ajout du champ tableau libre dans les block-publik : tableau_libre.j2
               Tableau de longueur libre (avec bouton "Ajouter une ligne")
Création sur le modèle de liste.j2 
les tableaux libres en yaml sont écrits comme les listes :
                     var_tab:
                             phrase de déclaration:
                                    - nom colonne 1
                                    - nom colonne 2